### PR TITLE
Adds "Sign in with Apple" step

### DIFF
--- a/CardinalKit-Example/CardinalKit-Example.entitlements
+++ b/CardinalKit-Example/CardinalKit-Example.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:cs342.page.link</string>

--- a/CardinalKit-Example/CardinalKit.xcodeproj/project.pbxproj
+++ b/CardinalKit-Example/CardinalKit.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		8E40DC042471E5940027536B /* CKNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E40DC032471E5940027536B /* CKNetworkManager.swift */; };
 		8E67519C24B7ACB7004EC405 /* StudyTableViewController+CardinalKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E67519B24B7ACB7004EC405 /* StudyTableViewController+CardinalKit.swift */; };
 		8EBE6F9C24B3C0E60093D07C /* AppDelegate+CardinalKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBE6F9B24B3C0E60093D07C /* AppDelegate+CardinalKit.swift */; };
+		D253D132250D1BDB00A363E4 /* CKSignInWithAppleStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253D131250D1BDB00A363E4 /* CKSignInWithAppleStep.swift */; };
 		E235077724F7082700CC1899 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E235077624F7082700CC1899 /* SceneDelegate.swift */; };
 		E290FB1D24FF4BBA00D19BE9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E290FB1C24FF4BBA00D19BE9 /* GoogleService-Info.plist */; };
 		E29143FC24E74AD100EE97B2 /* OnboardingUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29143FB24E74AD100EE97B2 /* OnboardingUI.swift */; };
@@ -100,6 +101,7 @@
 		8E67519B24B7ACB7004EC405 /* StudyTableViewController+CardinalKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StudyTableViewController+CardinalKit.swift"; sourceTree = "<group>"; };
 		8EBE6F9B24B3C0E60093D07C /* AppDelegate+CardinalKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CardinalKit.swift"; sourceTree = "<group>"; };
 		CB97C14C759E56B88E4E3941 /* Pods_CardinalKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CardinalKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D253D131250D1BDB00A363E4 /* CKSignInWithAppleStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CKSignInWithAppleStep.swift; sourceTree = "<group>"; };
 		E235077624F7082700CC1899 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E290FB1C24FF4BBA00D19BE9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E29143FB24E74AD100EE97B2 /* OnboardingUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUI.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				8E0A43A0244A4A0400656518 /* Views */,
+				D253D131250D1BDB00A363E4 /* CKSignInWithAppleStep.swift */,
 				8E0A439D244A4A0400656518 /* CKHealthDataStepViewController.swift */,
 				8E0A439F244A4A0400656518 /* PasswordlessLoginStep.swift */,
 				E2DF9F052500B9F000A93B93 /* LoginStep.swift */,
@@ -493,6 +496,7 @@
 				8E0A43AD244A4A0400656518 /* Constants.swift in Sources */,
 				8E0A43BE244A4A0400656518 /* CKHealthDataStepViewController.swift in Sources */,
 				8E0A43AE244A4A0400656518 /* ORKESerialization.m in Sources */,
+				D253D132250D1BDB00A363E4 /* CKSignInWithAppleStep.swift in Sources */,
 				8E0A43B2244A4A0400656518 /* StudyTableViewController.swift in Sources */,
 				8E0A43AC244A4A0400656518 /* CKStudyUser.swift in Sources */,
 				8E0A43C3244A4A0400656518 /* LoginCustomWaitStepViewController.swift in Sources */,

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKSignInWithAppleStep.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKSignInWithAppleStep.swift
@@ -84,8 +84,8 @@ public class CKSignInWithAppleStep: ORKInstructionStep {
         let config = CKPropertyReader(file: "CKConfiguration")
         self.requestedScopes = requestedScopes
         super.init(identifier: identifier)
-        self.title = title ?? config.read(query: "Sign in with Apple Title")
-        self.text = text ?? config.read(query: "Sign in with Apple Text")
+        self.title = title ?? config["Sign in with Apple"]["Title"] as! String
+        self.text = text ?? config["Sign in with Apple"]["Text"] as! String
     }
 
     @available(*, unavailable)

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKSignInWithAppleStep.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKSignInWithAppleStep.swift
@@ -1,0 +1,214 @@
+//
+//  CKSignInWithAppleStep.swift
+//
+//  Created for the CardinalKit Framework.
+//  Copyright © 2020 Stanford University. All rights reserved.
+//
+
+import ResearchKit
+import CardinalKit
+import CryptoKit
+import FirebaseAuth
+import AuthenticationServices
+
+/// A step that presents information about and performes
+/// [Sign in with Apple](https://developer.apple.com/sign-in-with-apple/).
+///
+/// ```
+/// // Initates the Sign in with Apple step:
+/// let signInWithAppleStep = CKSignInWithAppleStep(identifier: "SignInApple")
+/// // Adds the above step (with all other steps) into a task:
+/// let orderedTask = ORKOrderedTask(identifier: "StudyOnboardingTask", steps: [
+///     signInWithAppleStep, ...
+/// ])
+///
+/// // Then, in the delegate for the task view controller presenting such task:
+/// func taskViewController(_ taskViewController: ORKTaskViewController,
+///                         viewControllerFor step: ORKStep) -> ORKStepViewController? {
+///     // Use the correct view controller for this step.
+///     if step is CKSignInWithAppleStep {
+///         return CKSignInWithAppleStepViewController(step: step)
+///     }
+///     ...
+/// }
+///
+/// // That's it!
+/// ```
+///
+/// Additionally, you can direct the user to learn more about Sign in with Apple:
+///
+/// ```
+/// func taskViewController(_ taskViewController: ORKTaskViewController,
+///                         hasLearnMoreFor step: ORKStep) -> Bool {
+///     // Indicates the step should display learn more button.
+///     if step is CKSignInWithAppleStep {
+///         return true
+///     }
+///     ...
+/// }
+///
+///
+/// func taskViewController(_ taskViewController: ORKTaskViewController,
+///                         learnMoreForStep stepViewController: ORKStepViewController) {
+///     // Presents the "How to use Sign in with Apple" guide.
+///     if stepViewController is CKSignInWithAppleStepViewController {
+///         UIApplication.shared.open(URL(string: "https://support.apple.com/HT210318")!)
+///     }
+///     ...
+/// }
+/// ```
+///
+/// - Requires: View controller for this step is `CKSignInWithAppleStepViewController`.
+/// - Important: Though you don't have to write any code, you do need to setup Firebase and Xcode project
+/// following the [Firebase setup tutorial](https://firebase.google.com/docs/auth/ios/apple)
+/// - Note: [How to use Sign in with Apple](https://support.apple.com/HT210318) might be useful
+/// as the "Learn More" destination for this step.
+public class CKSignInWithAppleStep: ORKInstructionStep {
+    /// The contact information to be requested from the user during authentication.
+    public var requestedScopes: [ASAuthorization.Scope]
+
+    /// Returns a new step initialized with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - identifier: The unique identifier of the step.
+    ///   - title: The primary text to display for the step in a localized string.
+    ///   Defaults to the value of "Sign in with Apple Title" entry from `CKConfiguration.plist`.
+    ///   - text: Additional text to display for the step in a localized string.
+    ///   Defaults to the value of "Sign in with Apple Text" entry from `CKConfiguration.plist`.
+    ///   - requestedScopes: The contact information to be requested from the user during authentication.
+    ///   Defaults to email only.
+    public init(identifier: String,
+         title: String! = nil,
+         text: String! = nil,
+         requestedScopes: [ASAuthorization.Scope] = [.email]) {
+        let config = CKPropertyReader(file: "CKConfiguration")
+        self.requestedScopes = requestedScopes
+        super.init(identifier: identifier)
+        self.title = title ?? config.read(query: "Sign in with Apple Title")
+        self.text = text ?? config.read(query: "Sign in with Apple Text")
+    }
+
+    @available(*, unavailable)
+    public required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+public class CKSignInWithAppleStepViewController: ORKInstructionStepViewController,
+                                                  ASAuthorizationControllerDelegate {
+    /// The step presented by the step view controller.
+    public var signInWithAppleStep: CKSignInWithAppleStep! {
+        return step as? CKSignInWithAppleStep
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        continueButtonTitle = NSLocalizedString(
+            " Sign in with Apple",
+            comment: "Please use Apple's official translations"
+        )
+    }
+
+    /// Unhashed nonce.
+    private var currentNonce: String!
+
+    /// Initiates Sign in / up with Apple attempt.
+    public override func goForward() {
+        currentNonce = .makeRandomNonce()
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = signInWithAppleStep?.requestedScopes ?? [.email]
+        request.nonce = currentNonce.sha256
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.performRequests()
+    }
+
+    public func authorizationController(controller: ASAuthorizationController,
+                                        didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            print("Unable to obtain AppleID credentials")
+            return
+        }
+        guard let nonce = currentNonce else {
+            fatalError("Invalid state: A login callback was received, but no login request was sent.")
+        }
+        guard let appleIDToken = appleIDCredential.identityToken else {
+            print("Unable to fetch identity token")
+            return
+        }
+        guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+            print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+            return
+        }
+        // Initialize a Firebase credential.
+        let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                  idToken: idTokenString,
+                                                  rawNonce: nonce)
+        // Sign in with Firebase.
+        Auth.auth().signIn(with: credential) { (authResult, error) in
+            if let error = error {
+                self.showError(error)
+            } else {
+                // User is signed in to Firebase with Apple.
+                super.goForward()
+            }
+        }
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        showError(error)
+    }
+
+    /// Handle error.
+    private func showError(_ error: Error) {
+        // If error.code == .missingOrInvalidNonce,
+        // make sure you're sending the SHA256-hashed nonce as a hex string
+        // with your request to Apple.
+        print("Sign in with Apple errored: \(error)")
+        Alerts.showInfo(
+            title: NSLocalizedString("Failed to Sign in with Apple", comment: ""),
+            message: error.localizedDescription
+        )
+    }
+}
+
+fileprivate extension String {
+    var sha256: String {
+        return SHA256.hash(data: Data(utf8))
+            .compactMap { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    /// Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
+    static func makeRandomNonce(ofLength length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+
+            for random in randoms {
+                if remainingLength == 0 {
+                    break
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+}

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/LoginViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/LoginViewController.swift
@@ -9,10 +9,35 @@ import ResearchKit
 import Firebase
 
 class LoginViewController: ORKLoginStepViewController {
+    override func goForward() {
+        if let emailRes = result?.results?.first as? ORKTextQuestionResult, let email = emailRes.textAnswer,
+           let passwordRes = result?.results?[1] as? ORKTextQuestionResult, let pass = passwordRes.textAnswer {
+            let alert = UIAlertController(title: nil, message: "Logging in...", preferredStyle: .alert)
+
+            let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
+            loadingIndicator.hidesWhenStopped = true
+            loadingIndicator.style = UIActivityIndicatorView.Style.medium
+            loadingIndicator.startAnimating()
+            alert.view.addSubview(loadingIndicator)
+
+            taskViewController?.present(alert, animated: true, completion: nil)
+
+            Auth.auth().signIn(withEmail: email, password: pass) { (res, error) in
+                if let error = error {
+                    alert.dismiss(animated: true) {
+                        let alert = UIAlertController(title: "Login Error!", message: error.localizedDescription, preferredStyle: .alert)
+                        alert.addAction(UIAlertAction(title: "Ok", style: .cancel))
+                        self.taskViewController?.present(alert, animated: true)
+                    }
+                } else {
+                    alert.dismiss(animated: true, completion: nil)
+                    super.goForward()
+                }
+            }
+        }
+    }
     
     override func forgotPasswordButtonTapped() {
-        let config = CKPropertyReader(file: "CKConfiguration")
-        
         let alert = UIAlertController(title: "Reset Password", message: "Enter your email to get a link for password reset.", preferredStyle: .alert)
         
         alert.addTextField { (textField) in

--- a/CardinalKit-Example/CardinalKit/Supporting Files/CKConfiguration-example.plist
+++ b/CardinalKit-Example/CardinalKit/Supporting Files/CKConfiguration-example.plist
@@ -42,6 +42,15 @@
 	<string>On the next screen, you will be prompted to grant access to read and write some of your general and health information, such as height, weight, and steps taken so you don&apos;t have to enter it again.</string>
 	<key>Background Read Frequency</key>
 	<string>immediate</string>
+	<key>Sign in with Apple</key>
+	<dict>
+		<key>Enabled</key>
+		<false/>
+		<key>Title</key>
+		<string>Sign in with Apple</string>
+		<key>Text</key>
+		<string>Sign in using your Apple ID is fast and easy, and Apple will not track any of your activities.</string>
+	</dict>
 	<key>Login Step Title</key>
 	<string>Almost done!</string>
 	<key>Login Step Text</key>

--- a/CardinalKit-Example/CardinalKit/Supporting Files/CKConfiguration.plist
+++ b/CardinalKit-Example/CardinalKit/Supporting Files/CKConfiguration.plist
@@ -42,6 +42,15 @@
 	<string>On the next screen, you will be prompted to grant access to read and write some of your general and health information, such as height, weight, and steps taken so you don&apos;t have to enter it again.</string>
 	<key>Background Read Frequency</key>
 	<string>immediate</string>
+	<key>Sign in with Apple</key>
+	<dict>
+		<key>Enabled</key>
+		<true/>
+		<key>Title</key>
+		<string>Sign in with Apple</string>
+		<key>Text</key>
+		<string>Sign in using your Apple ID is fast and easy, and Apple will not track any of your activities.</string>
+	</dict>
 	<key>Login Step Title</key>
 	<string>Almost done!</string>
 	<key>Login Step Text</key>

--- a/CardinalKit-Example/CardinalKit/Supporting Files/CKPropertyReader.swift
+++ b/CardinalKit-Example/CardinalKit/Supporting Files/CKPropertyReader.swift
@@ -43,7 +43,11 @@ public class CKPropertyReader {
     func readDict(query: String) -> [String:String] {
         return data[query] as! [String:String]
     }
-    
+
+    subscript(query: String) -> [String: AnyObject] {
+        return data[query] as! [String: AnyObject]
+    }
+
     // read from stored dictionary
     func readArray(query: String) -> [String] {
         return data[query] as! [String]


### PR DESCRIPTION
# Usage

1. Follow the [Firebase setup tutorial](https://firebase.google.com/docs/auth/ios/apple) until right before the "Sign in with Apple and authenticate with Firebase" section to setup Firebase and Xcode project.
2. Instantiate a Sign in with Apple step. By default, it uses the "**Sign in with Apple Title**" and "**Sign in with Apple Text**" entry from `CKConfiguration.plist`, and collects user's email address:
```swift
let signInWithAppleStep = CKSignInWithAppleStep(identifier: "SignInWithAppleStep")
```
3. (Optionally,) further customize the step in code. For example, to collect both the name and the email of a user:
```swift
signInWithAppleStep.requestedScopes = [.fullName, .email]
```
4. Add the above step to a task.
5. Configure the task presentation view controller to use the correct view controller for this step:
```swift
func taskViewController(_ taskViewController: ORKTaskViewController,
                        viewControllerFor step: ORKStep) -> ORKStepViewController? {
    // Use the correct view controller for this step.
    if step is CKSignInWithAppleStep {
        return CKSignInWithAppleStepViewController(step: step)
    }
    ...
}
```
