### PR TITLE
Set HealthKit and Health Records permissions when logging in with exi…

### DIFF
--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/LoginExistingUserViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/LoginExistingUserViewController.swift
@@ -46,9 +46,12 @@ struct LoginExistingUserViewController: UIViewControllerRepresentable {
         }
         passcodeStep.text = config.read(query: "Passcode Text")
         
-        loginSteps += [passcodeStep]
+        // set health data permissions
+        let healthDataStep = CKHealthDataStep(identifier: "HealthKit")
+        let healthRecordsStep = CKHealthRecordsStep(identifier: "HealthRecords")
         
         // create a task with each step
+        loginSteps += [passcodeStep, healthDataStep, healthRecordsStep]
         let orderedTask = ORKOrderedTask(identifier: "StudyLoginTask", steps: loginSteps)
         
         // wrap that task on a view controller


### PR DESCRIPTION
# Related Issue	
App does not set HealthKit and Health Records permissions as part of onboarding steps when logging on with an existing user account.

# Changes Proposed
Adds steps for setting HealthKit and Health Records permissions when onboarding with an existing user account.
