### PR TITLE
Fixes cancel button on Change Passcode view

### DIFF
--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/PasscodeViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/PasscodeViewController.swift
@@ -39,7 +39,7 @@ struct PasscodeViewController: UIViewControllerRepresentable {
 
     class Coordinator: NSObject, ORKPasscodeDelegate {
         func passcodeViewControllerDidCancel(_ viewController: UIViewController) {
-            
+            viewController.dismiss(animated: true, completion: nil)
         }
         
         func passcodeViewControllerDidFinish(withSuccess viewController: UIViewController) {


### PR DESCRIPTION
# Related Issue	
The cancel button on the Change Passcode view was not dismissing the modal.