### PR TITLE
Fix transparent navbar in iOS 15

### DIFF
--- a/CardinalKit-Example/CardinalKit/AppDelegate.swift
+++ b/CardinalKit-Example/CardinalKit/AppDelegate.swift
@@ -30,6 +30,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let config = CKPropertyReader(file: "CKConfiguration")
         UIView.appearance(whenContainedInInstancesOf: [ORKTaskViewController.self]).tintColor = config.readColor(query: "Tint Color")
         
+        // Fix transparent navbar in iOS 15
+        if #available(iOS 15, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
+        
         return true
     }
     


### PR DESCRIPTION
Fixes transparent navbar in iOS 15 as per the solution given here:
 https://stackoverflow.com/questions/69111478/ios-15-navigation-bar-transparent