### PR TITLE
effectiveDate change so future cloud surveys appear

### DIFF
--- a/CardinalKit-Example/CardinalKit/Library/CareKit/CKCareKitManager+Sample.swift
+++ b/CardinalKit-Example/CardinalKit/Library/CareKit/CKCareKitManager+Sample.swift
@@ -122,6 +122,12 @@ internal extension OCKStore {
                         }
                         task.instructions = payload["instructions"] as? String
 
+                        // This fixes an issue where if cloud surveys were all in the future,
+                        // they would not show up
+                        // It does open up all surveys (even future) for completion
+                        // TODO: make a way for the future surveys to be visible but not fillable
+                        task.effectiveDate = Date()
+
                         // get if task exist?
                         self.fetchTask(withID: id) { result in
                             switch result {


### PR DESCRIPTION
There was an issue where if no cloud surveys were scheduled for the day of viewing, future cloud surveys would appear blank

#### Caveats	
- All future surveys are fillable
- Would be nice to implement some additional solution that prevented filling future surveys until specified date
<!-- If there is anything hacky or unique being added in your code please define it.--> 

#### Error before fix shown below
- Date of screenshot 1/16/22
- Date of first task startTime 1/18/22
![Simulator Screen Shot - iPhone 13 - 2022-01-16 at 12 20 11](https://user-images.githubusercontent.com/11847434/149672649-b6704dbb-b9a5-4255-85ab-bb3590109bde.png)

