### PR TITLE
Update rather than wipe user

### DIFF
--- a/CardinalKit-Example/CardinalKit/Library/Auth/CKStudyUser.swift
+++ b/CardinalKit-Example/CardinalKit/Library/Auth/CKStudyUser.swift
@@ -120,7 +120,7 @@ class CKStudyUser {
             settings.isPersistenceEnabled = false
             let db = Firestore.firestore()
             db.settings = settings
-            db.collection(dataBucket).document(uid).setData(["userID":uid, "lastActive":Date().ISOStringFromDate(),"email":email])
+            db.collection(dataBucket).document(uid).setData(["userID":uid, "lastActive":Date().ISOStringFromDate(),"email":email], merge: true)
         }
     }
     


### PR DESCRIPTION
If wanting to save data other than "userID", "lastActive", "email" to uid document, prior settings would overwrite changes. This allows other data to remain while updating desired variables. 

Idea for this is that if you want to save other variables from the web interface onto the user document, then using the app won't destroy those variables
