### PR TITLE
Fix for ambiguous type error in HealthKitData

### DIFF
--- a/CardinalKit/Source/Components/HealthKit/Models/HealthKitData.swift
+++ b/CardinalKit/Source/Components/HealthKit/Models/HealthKitData.swift
@@ -35,11 +35,11 @@ class HealthKitData: Object, Mappable, Codable {
     
     @objc dynamic var passiveWhenCollected : Bool = false
     
-    required convenience init?(map: Map) {
+    required convenience init?(map: ObjectMapper.Map) {
         self.init()
     }
     
-    func mapping(map: Map) {
+    func mapping(map: ObjectMapper.Map) {
         startDate <- map["start_date"]
         endDate <- map["end_date"]
         date <- map["date"]


### PR DESCRIPTION
Fixes ambiguous type error caused by upgrading RealmSwift to 10.25.x.