### PR TITLE
Updates build action to use MacOS 12 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-12
     defaults:
       run:
         working-directory: CardinalKit-Example


### PR DESCRIPTION
The default MacOS runner is 11, which has a maximum supported Xcode version of 13.2.1 and leads to a build error due to lack of support for Swift 5.5.