### PR TITLE
Fix Deployment Issues Due to Xcode Update

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,6 +35,10 @@ platform :ios do
     cocoapods(
       podfile: "./CardinalKit-Example/"
     )
+    update_project_team(
+      path: "CardinalKit-Example/Pods/Pods.xcodeproj",
+      teamid: ENV["TEAM_ID"]
+    )
     build_app
     upload_to_testflight
   end

--- a/fastlane/Gymfile
+++ b/fastlane/Gymfile
@@ -16,6 +16,8 @@ scheme("CardinalKit-Example")
 
 workspace("CardinalKit-Example/CardinalKit.xcworkspace")
 
+export_team_id(ENV["TEAM_ID"])
+
 export_options(
   {
     provisioningProfiles: { 


### PR DESCRIPTION
Fixes the issue that newer Xcode versions (from 14.X) require more detailed information to sign an application for archiving. We specify and define the team ID in the Pods project and update the certificates and profiles found in the GitHub secrets. 