### PR TITLE
Deploy beta on workflow_dispatch

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -9,9 +9,6 @@
 name: Beta Deployment
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR modifies the beta-deployment action to deploy to TestFlight on workflow_dispatch, as deploying is not necessary on every push to main.
