### PR TITLE
Adds activity indicators to health data permissions steps in onboarding

### DIFF
--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKHealthDataStepViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKHealthDataStepViewController.swift
@@ -46,6 +46,8 @@ class CKHealthDataStepViewController: ORKInstructionStepViewController {
      Relies on a `CKHealthDataStep` instance as `self.step`.
     */
     override func goForward() {
+        self.showActivityIndicator(inContinueButton: true)
+        
         let manager = CKHealthKitManager.shared
         manager.getHealthAuthorization { _, _ in
             OperationQueue.main.addOperation {

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKHealthRecordsStepViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKHealthRecordsStepViewController.swift
@@ -49,6 +49,8 @@ class CKHealthRecordsStepViewController: ORKInstructionStepViewController {
      Relies on a `CKHealthDataStep` instance as `self.step`.
     */
     override func goForward() {
+        self.showActivityIndicator(inContinueButton: true)
+        
         let manager = CKHealthRecordsManager.shared
         manager.getAuth { succeeded, _ in
             if succeeded {

--- a/CardinalKit-Example/CardinalKit/Library/HealthKit/CKHealthRecordsManager.swift
+++ b/CardinalKit-Example/CardinalKit/Library/HealthKit/CKHealthRecordsManager.swift
@@ -32,8 +32,9 @@ class CKHealthRecordsManager: NSObject {
     override init() {
         super.init()
         for id in typesById {
-            print(id.rawValue)
-            guard let record = HKObjectType.clinicalType(forIdentifier: id) else { continue }
+            guard let record = HKObjectType.clinicalType(forIdentifier: id) else {
+                continue
+            }
             types.insert(record)
         }
     }


### PR DESCRIPTION
Users have noted that on some devices there is a delay in the health data permissions views appearing after tapping the "Next" button on the corresponding onboarding step. This delay is intrinsic to HealthKit, but in this PR we add an activity indicator so that users will be aware that the permissions views are in the progress of being presented.