### PR TITLE
Replaces deprecated ORKVisualConsentStep with ORKInstructionStep

### DIFF
--- a/CardinalKit-Example/CardinalKit.xcodeproj/project.pbxproj
+++ b/CardinalKit-Example/CardinalKit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		276399A129021BB5004DE158 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 276399A029021BB4004DE158 /* GoogleService-Info.plist */; };
 		27653A13272A2E7700D74E83 /* LocalTaskListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27653A12272A2E7700D74E83 /* LocalTaskListItemView.swift */; };
 		27663F2A29574F1500A34080 /* CardinalKit_ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27663F2929574F1500A34080 /* CardinalKit_ExampleTests.swift */; };
+		27797418296289F2006D6DE5 /* CKInstructionSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27797417296289F2006D6DE5 /* CKInstructionSteps.swift */; };
 		2B19DD9226FE1BEB00649CE1 /* JsonToSurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B19DD9126FE1BEB00649CE1 /* JsonToSurvey.swift */; };
 		2B19DD9426FE1D2600649CE1 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B19DD9326FE1D2600649CE1 /* TestViewController.swift */; };
 		2B19DD9626FE1D2F00649CE1 /* CheckListItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B19DD9526FE1D2F00649CE1 /* CheckListItemViewController.swift */; };
@@ -127,6 +128,7 @@
 		27653A12272A2E7700D74E83 /* LocalTaskListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalTaskListItemView.swift; sourceTree = "<group>"; };
 		27663F2729574F1500A34080 /* CardinalKit ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CardinalKit ExampleTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27663F2929574F1500A34080 /* CardinalKit_ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardinalKit_ExampleTests.swift; sourceTree = "<group>"; };
+		27797417296289F2006D6DE5 /* CKInstructionSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKInstructionSteps.swift; sourceTree = "<group>"; };
 		2B19DD9126FE1BEB00649CE1 /* JsonToSurvey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonToSurvey.swift; sourceTree = "<group>"; };
 		2B19DD9326FE1D2600649CE1 /* TestViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
 		2B19DD9526FE1D2F00649CE1 /* CheckListItemViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckListItemViewController.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				2B8FB80327552B02000B2D7B /* CKMultipleSignInStep.swift */,
 				2B932F83276BF8D300AB3A02 /* CKVerifyConsentDocumentStep.swift */,
 				E2DF9F092500C9CE00A93B93 /* CKLoginStepViewController.swift */,
+				27797417296289F2006D6DE5 /* CKInstructionSteps.swift */,
 			);
 			path = Steps;
 			sourceTree = "<group>";
@@ -857,6 +860,7 @@
 				8E6E1E2E25353A1E0024B8DF /* PatientIDView.swift in Sources */,
 				8E6E1E0B2534FF640024B8DF /* OnboardingViewController+Coordinator.swift in Sources */,
 				8EA664B025941A4D00B6A45A /* SurveyItemViewController.swift in Sources */,
+				27797418296289F2006D6DE5 /* CKInstructionSteps.swift in Sources */,
 				8E9CDEBA2591843200C8A228 /* CKConfig.swift in Sources */,
 				2F94C5F22536543600DF8866 /* SceneDelegate+CardinalKit.swift in Sources */,
 				8E9CDFAE2592B79900C8A228 /* Metrics.swift in Sources */,

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/OnboardingViewController.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/OnboardingViewController.swift
@@ -25,6 +25,9 @@ struct OnboardingViewController: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> ORKTaskViewController {
         let config = CKPropertyReader(file: "CKConfiguration")
 
+        /// Show instruction steps
+        let instructionSteps = CKInstructionSteps.steps
+
         /// Ask user to review, then sign consent form.
         let consentDocument = ConsentDocument()
         let signature = consentDocument.signatures?.first
@@ -101,6 +104,9 @@ struct OnboardingViewController: UIViewControllerRepresentable {
         
         /// Create an array with the steps to show users
         var onboardingSteps: [ORKStep] = []
+
+        /// Add instruction steps
+        onboardingSteps += instructionSteps
 
         /// Add consent steps
         onboardingSteps.append(reviewConsentStep)

--- a/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKInstructionSteps.swift
+++ b/CardinalKit-Example/CardinalKit/Components/Onboarding/Steps/CKInstructionSteps.swift
@@ -1,0 +1,46 @@
+//
+//  CKInstructionSteps.swift
+//  CardinalKit_Example
+//
+//  Created by Vishnu Ravi on 1/1/23.
+//  Copyright © 2023 CardinalKit. All rights reserved.
+//
+
+import ResearchKit
+
+
+struct CKInstructionSteps {
+    /// Creates individual instruction steps that summarize the sections in the study consent,
+    /// with titles and text pulled from CKConfiguration.plist.
+    ///
+    /// This may be replaced with your own custom instruction steps for your onboarding workflow.
+    static var steps: [ORKInstructionStep] = {
+        let config = CKConfig.shared
+        let instructionSteps = config["Consent Form"] as? [String: [String: String]]
+
+        let stepKeys = [
+            "Overview",
+            "DataGathering",
+            "Privacy",
+            "DataUse",
+            "TimeCommitment",
+            "StudySurvey",
+            "StudyTasks"
+        ]
+
+        var steps = [ORKInstructionStep]()
+
+        for key in stepKeys {
+            guard let title = instructionSteps?[key]?["Title"],
+                  let summary = instructionSteps?[key]?["Summary"] else {
+                continue
+            }
+            let step = ORKInstructionStep(identifier: "\(key)Step")
+            step.title = title
+            step.text = summary
+            steps.append(step)
+        }
+
+        return steps
+    }()
+}


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Replaces deprecated `ORKVisualConsentStep` with `ORKInstructionStep`

## :recycle: Current situation & Problem
ResearchKit version 2.1.1 has deprecated the `ORKVisualConsentStep`.

## :bulb: Proposed solution
This PR displays the content that was previously using `ORKVisualConsentStep` with `ORKInstructionStep`s instead.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

