### PR TITLE
Changing stepCount casting to Int in HealthKitDataSync

### DIFF
--- a/CardinalKit-Example/Podfile.lock
+++ b/CardinalKit-Example/Podfile.lock
@@ -912,11 +912,11 @@ SPEC CHECKSUMS:
   ReachabilitySwift: f5b9bb30a0777fac8f09ce8b067e32faeb29bb64
   Realm: d4f810e161fa2c2c589b9860b6eb09238deacd73
   RealmSwift: cef9946f09f2333a8f2ac8bac4f8de52fb9f5ac3
-  ResearchKit: 70c28052fabb418069ab0dcea9888edf364edfe3
+  ResearchKit: ed3bbd6f8c8d03e35dbadf399c34ff478751271b
   SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
 PODFILE CHECKSUM: 188dda7f6732ea23699ef6c0faa04938557daa58
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/CardinalKit/Source/Components/HealthKit/HealthKitDataSync.swift
+++ b/CardinalKit/Source/Components/HealthKit/HealthKitDataSync.swift
@@ -323,7 +323,7 @@ extension HealthKitDataSync {
     }
     
     fileprivate func sendActivityIndex(forDate date: Date,value: Double, stepCount:Double){
-        let dictionary=["date":date.shortStringFromDate(),"activityindex":String(value),"stepCount":String(stepCount)]
+        let dictionary=["date":date.shortStringFromDate(),"activityindex":String(value),"stepCount":Int(stepCount)] as [String : Any]
         do{
             let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
             let package = try Package("metrics"+date.shortStringFromDate(), type: .metricsData, data: data)


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# *Changing stepCount casting to Int in HealthKitDataSync*

## :recycle: Current situation & Problem
*Currently, stepCount obtained from HealthKit is being written to Firebase as a string. For example, it appears as "14582.0". Having stepCount as a string with a trailing zero requires recasting to float, and then int by users.*
*Please link any open issue that is addressed with this PR*

## :bulb: Proposed solution
*The solution is to change the casting of stepCount in sendActivityIndex() from String to Int.*

## :gear: Release Notes 
*Line 326 on HealthKitDataSync was changed. Initially, stepCount was a double that was being recasted to String. This was changed to `"stepCount":Int(stepCount)`. The following was added as well: `as [String: Any]`. The full line modified is below.*
*```let dictionary=["date":date.shortStringFromDate(),"activityindex":String(value),"stepCount":Int(stepCount)] as [String : Any]```*

## :heavy_plus_sign: Additional Information
*N/A*

### Related PRs
*N/A*

### Testing
*Tests were conducted on my configuration, connected with Firebase. Recasting double to Int, as opposed to String, will not cause any unforeseen results.*

### Reviewer Nudging
*Pods -> Development Pods -> CardinalKit -> Components -> HealthKit -> HealthKitDataSync -> Line 326*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

